### PR TITLE
Change subprocess logging and add few files to setup.py

### DIFF
--- a/edalize/edatool.py
+++ b/edalize/edatool.py
@@ -292,9 +292,11 @@ class Edatool(object):
             logger.debug("Environment: " + str(_env))
             logger.debug("Working directory: " + self.work_root)
             try:
-                subprocess.check_call(script['cmd'],
+                sp_output = subprocess.check_output(script['cmd'],
                                       cwd = self.work_root,
-                                      env = _env)
+                                      env = _env,
+                                      stderr=subprocess.STDOUT)
+                logger.info(sp_output)
             except FileNotFoundError as e:
                 msg = "Unable to run {} script '{}': {}"
                 raise RuntimeError(msg.format(hook_name, script['name'], str(e)))
@@ -307,9 +309,11 @@ class Edatool(object):
         logger.debug("args  : " + ' '.join(args))
 
         try:
-            subprocess.check_call([cmd] + args,
+            sp_output = subprocess.check_output([cmd] + args,
                                   cwd = self.work_root,
-                                  stdin=subprocess.PIPE),
+                                  stdin=subprocess.PIPE,
+                                  stderr=subprocess.STDOUT),
+            logger.info(sp_output)
         except FileNotFoundError:
             _s = "Command '{}' not found. Make sure it is in $PATH"
             raise RuntimeError(_s.format(cmd))

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,8 @@ setup(
         'templates/ascentlint/Makefile.j2',
         'templates/ascentlint/run-ascentlint.tcl.j2',
         'templates/symbiflow/symbiflow-makefile.j2',
+        'templates/yosys/yosys-makefile.j2',
+        'templates/yosys/yosys-script-tcl.j2',
     ]},
     author = "Olof Kindgren",
     author_email = "olof.kindgren@gmail.com",

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         'templates/trellis/trellis-makefile.j2',
         'templates/ascentlint/Makefile.j2',
         'templates/ascentlint/run-ascentlint.tcl.j2',
+        'templates/symbiflow/symbiflow-makefile.j2',
     ]},
     author = "Olof Kindgren",
     author_email = "olof.kindgren@gmail.com",


### PR DESCRIPTION
This PR changes destination of subprocess output. Previously this output was passed to stdout of a parent process, flooding console with synthesis tool's output. This output was redirected to the existing logger utility. Toolchain output is stored in .log files inside build directory and console output is cleaner.

This PR also adds some missing files to setup.py so they will be installed in system when setup.py script is executed.