### PR TITLE
fix yosys-vivado template

### DIFF
--- a/edalize/templates/vivado/vivado-run-yosys.tcl.j2
+++ b/edalize/templates/vivado/vivado-run-yosys.tcl.j2
@@ -6,9 +6,18 @@ read_xdc {{ xdc_file }}
 
 link_design -top {{ name }} -part {{ tool_options.part }}
 
-opt_design
-place_design
+# Vivado will raise an error if impl_1 is launched when it is already done. So
+# check the progress first and only launch if its not complete.
+if { [get_property PROGRESS [get_runs impl_1]] != "100%"} {
+  launch_runs impl_1 -to_step write_bitstream
+  wait_on_run impl_1
+  puts "Bitstream generation completed"
+} else {
+  puts "Bitstream generation already complete"
+}
+
 report_utilization -file top_utilization_placed.rpt
-route_design
-phys_opt_design
-write_bitstream -force {{ name }}.bit
+report_timing_summary -file top_timing_summary_routed.rpt
+
+set vivadoDefaultBitstreamFile [ get_property DIRECTORY [current_run] ]/[ get_property top [current_fileset] ].bit
+file copy -force $vivadoDefaultBitstreamFile [pwd]/[current_project].bit


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR changes the run-vivado-yosys template to launch a run instead of running single commands.

This is needed to correctly extract run-time information of the implementation steps.